### PR TITLE
Basic autocomplete

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ pub mod input;
 pub mod io;
 pub mod resource;
 mod ui;
-pub mod utils;
+mod utils;
 
 use crossterm::{event::*, execute, terminal::*};
 use ratatui::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ pub mod input;
 pub mod io;
 pub mod resource;
 mod ui;
+pub mod utils;
 
 use crossterm::{event::*, execute, terminal::*};
 use ratatui::prelude::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,19 +1,17 @@
 ///Returns greatest common prefix of two strings
 fn gcp(s1: String, s2: String) -> String {
-    if let Some((idx, (_, _))) = s1
-        .chars()
-        .zip(s2.chars())
-        .enumerate()
-        .find(|(_, (c1, c2))| c1 != c2)
-    {
-        s1[..idx].to_string()
-    } else {
-        s1[..s1.len().min(s2.len())].to_string()
+    let mut idx = 0;
+    for (c1, c2) in s1.chars().zip(s2.chars()) {
+        if c1 != c2 {
+            break;
+        }
+        idx += 1
     }
+    s1[..idx].to_string()
 }
 
 ///Returns greatest common prefix of all strings from the vector that contain specified prefix
-///If none of the strings contain specified prefix returns prefix
+///If none of the strings contain specified prefix returns it
 pub fn complete(mut filenames: Vec<String>, prefix: &String) -> String {
     filenames.retain(|s| s.starts_with(prefix));
     filenames

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,17 @@
+fn gcp(s1: String, s2: String) -> String {
+    let ((_, _), idx) = s1
+        .chars()
+        .zip(s2.chars())
+        .zip(0..s1.len())
+        .find(|((c1, c2), _)| c1 != c2)
+        .unwrap_or((('0', '0'), s1.len().min(s2.len())));
+    s1[..idx].to_string()
+}
+
+pub fn complete(mut filenames: Vec<String>, prefix: &String) -> String {
+    filenames.retain(|s| s.starts_with(prefix));
+    filenames
+        .into_iter()
+        .reduce(gcp)
+        .unwrap_or(prefix.to_string())
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,19 @@
+///Returns greatest common prefix of two strings
 fn gcp(s1: String, s2: String) -> String {
-    let ((_, _), idx) = s1
+    if let Some((idx, (_, _))) = s1
         .chars()
         .zip(s2.chars())
-        .zip(0..s1.len())
-        .find(|((c1, c2), _)| c1 != c2)
-        .unwrap_or((('0', '0'), s1.len().min(s2.len())));
-    s1[..idx].to_string()
+        .enumerate()
+        .find(|(_, (c1, c2))| c1 != c2)
+    {
+        s1[..idx].to_string()
+    } else {
+        s1[..s1.len().min(s2.len())].to_string()
+    }
 }
 
+///Returns greatest common prefix of all strings from the vector that contain specified prefix
+///If none of the strings contain specified prefix returns prefix
 pub fn complete(mut filenames: Vec<String>, prefix: &String) -> String {
     filenames.retain(|s| s.starts_with(prefix));
     filenames


### PR DESCRIPTION
closes #4
Added basic autocomplete functionality. When tab is pressed current search entry is completed up to the greatest common prefix of all file paths that match currently entered one.
Example:
```
.
│
└───foo
│   │   file1.txt
│   │   file2.txt
│      
└───bar
    │   file1.txt
    │   file2.txt
```

`f -> foo`
`foo/f -> foo/file`
`foo/file2 -> foo/file2.txt`