### PR TITLE
Change log output dir (Log enhancement not included)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,10 +215,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -262,6 +294,16 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "lock_api"
@@ -342,6 +384,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -426,6 +474,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "refer"
 version = "0.1.0"
 dependencies = [
@@ -433,6 +492,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "dirs",
  "log",
  "ratatui",
  "sha1_smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ ansi-to-tui = "4.0.1"
 anyhow = "1.0.86"
 clap = { version = "4.5.7", features = ["derive"] }
 crossterm = "0.27.0"
+dirs = "5.0.1"
 log = "0.4.22"
 ratatui = { version = "0.26.3", features = ["macros"] }
 sha1_smol = { version = "1.0.1", features = ["alloc", "std"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use crossterm::{event::*, execute, terminal::*};
 use ratatui::prelude::*;
 use simplelog::WriteLogger;
 use std::{
-    fs::File,
+    fs::{create_dir_all, OpenOptions},
     io::{stdout, Stdout},
     ops::Drop,
     rc::Rc,
@@ -132,12 +132,30 @@ pub fn bounded_add(value: usize, other: usize, bound: usize) -> usize {
 }
 
 fn create_logger() -> anyhow::Result<()> {
-    let file = File::create(LOGFILE_NAME)
+    let log_dir = dirs::cache_dir()
+        .ok_or_else(|| anyhow::anyhow!("Couldn't find cache directory"))?
+        .join("refer")
+        .join("log");
+
+    if !log_dir.exists() {
+        create_dir_all(&log_dir)
+            .map_err(|err| anyhow::anyhow!("Couldn't create the directory due to: {err}"))?;
+    }
+
+    let log_path = log_dir.join(LOGFILE_NAME);
+
+    let log_file = OpenOptions::new()
+        .write(true)
+        .append(true)
+        .create(true)
+        .open(log_path)
         .map_err(|err| anyhow::anyhow!("Couldn't create the log file due to: {err}"))?;
+
     WriteLogger::init(
         simplelog::LevelFilter::Trace,
         simplelog::Config::default(),
-        file,
+        log_file,
     )?;
+
     Ok(())
 }


### PR DESCRIPTION
### Overview
This Pull Request is about changing the log output destination.

### Changes
- **Log Output Destination Change**: 
  - The log output destination has been updated to `$HOME/.cache/refer/log/refer.log`.

- **Log Enhancement**:
  - Work on improving the logs is still in progress and might take a bit more time to implement.
  - I'll provide more details on the enhancement in future Pull Requests.

### Next Steps
I'll create a separate issue for the log enhancement and submit a PR once it's done. This PR mainly focuses on changing the log output destination, so I'd appreciate your review and merge.

### Related Issue
- #7